### PR TITLE
Implement shared mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ defmodule MyApplication do
 end
 ```
 
-- `register/2`. Use this function in your tests to register a stubbed implementation for a module.
+- `register/2` `register/3`. Use this function in your tests to register a stubbed implementation for a module.
 
 ```elixir
 defmodule MyApplicationTest do
@@ -66,6 +66,14 @@ defmodule MyApplicationTest do
     {:ok, nil} = MyApplication.process()
   end
 end
+```
+
+### Shared Mode
+If you want to inject a dependency that will be shared by all processes, you can do so by passing the `shared: true` option.
+This can be useful if you have background processing. This is only recommended for tests that do not run async.
+
+```elixir
+register(File, FileStub, shared: true)
 ```
 
 ## TODO

--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -1,7 +1,11 @@
 defmodule Inject do
-  def register(source_module, inject_module) do
+  def register(source_module, inject_module, opts \\ []) do
+    shared = opts |> Keyword.get(:shared, false)
     :ok = Registry.unregister(Inject.Registry, source_module)
-    {:ok, _} = Registry.register(Inject.Registry, source_module, inject_module)
+
+    {:ok, _} =
+      Registry.register(Inject.Registry, source_module, {inject_module, [shared: shared]})
+
     :ok
   end
 
@@ -21,8 +25,8 @@ defmodule Inject do
 
   defp find_override([]), do: nil
 
-  defp find_override([{pid, override} | overrides]) do
-    if pid == self() do
+  defp find_override([{pid, {override, shared: shared}} | overrides]) do
+    if pid == self() || shared do
       override
     else
       find_override(overrides)

--- a/test/inject_test.exs
+++ b/test/inject_test.exs
@@ -1,6 +1,6 @@
 defmodule InjectTest do
   use ExUnit.Case
-  import Inject, only: [i: 1, register: 2]
+  import Inject
   doctest Inject
 
   defmodule ExampleModule do
@@ -63,21 +63,21 @@ defmodule InjectTest do
     end
   end
 
-  # TODO implement allowing other processes
-  # describe "when allowing another process" do
-  # test "it injects dependencies within another process" do
-  # test_pid = self()
-  # pid = spawn fn ->
-  # receive do
-  # :go -> send test_pid, i(ExampleModule).hello()
-  # end
-  # end
+  describe "when registering in shared mode" do
+    test "it allows any other processes to use the registration" do
+      test_pid = self()
 
-  # register(ExampleModule, StubModule)
-  # allow(pid)
+      pid =
+        spawn(fn ->
+          receive do
+            :go -> send(test_pid, i(ExampleModule).hello())
+          end
+        end)
 
-  # send pid, :go
-  # assert_receive "stubbed"
-  # end
-  # end
+      register(ExampleModule, StubModule, shared: true)
+
+      send(pid, :go)
+      assert_receive "stubbed"
+    end
+  end
 end


### PR DESCRIPTION
Adding `shared: true` option for `register/3` so you can register an implementation to be used by all processes for the duration of a test.  Works similarly to SqlSandbox shared mode.

`register(ExampleModule, StubModule, shared: true)`