### PR TITLE
Fix the :already_registered error

### DIFF
--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -2,11 +2,7 @@ defmodule Inject do
   def register(source_module, inject_module, opts \\ []) do
     shared = opts |> Keyword.get(:shared, false)
     :ok = Registry.unregister(Inject.Registry, source_module)
-
-    {:ok, _} =
-      Registry.register(Inject.Registry, source_module, {inject_module, [shared: shared]})
-
-    :ok
+    :ok = try_register(source_module, inject_module, [shared: shared], 1)
   end
 
   def i(mod) do
@@ -20,6 +16,21 @@ defmodule Inject do
       Inject.Registry
       |> Registry.lookup(mod)
       |> find_override() || mod
+    end
+  end
+
+  # It seems that unregister doesn't always take immediate effect so we try a few times.
+  defp try_register(_source_module, _inject_module, _opts, 4) do
+    {:error, "Too many attempts to register an already registered module"}
+  end
+
+  defp try_register(source_module, inject_module, opts, attempt) do
+    case Registry.register(Inject.Registry, source_module, {inject_module, opts}) do
+      {:ok, _} ->
+        :ok
+
+      {:error, {:already_registered, _}} ->
+        try_register(source_module, inject_module, opts, attempt + 1)
     end
   end
 


### PR DESCRIPTION
I started to receive these errors when trying to register:
```
{:error, {:already_registered, <pid>}}
```
It seems like `Register.unregister` doesn't take effect immediately at times.  So, we try a few times to make it more resilient.  Seems to resolve my issues.  Hopefully I'm not just doing something wrong. 