### PR TITLE
convert inject/1 to a macro

### DIFF
--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -8,19 +8,21 @@ defmodule Inject do
     :ok
   end
 
-  def i(mod) do
-    inject(mod)
-  end
-
-  def inject(mod) do
+  defmacro inject(mod) do
     if Application.get_env(:inject, :disabled) do
       mod
     else
-      Inject.Registry
-      |> Registry.lookup(mod)
-      |> Enum.reverse()
-      |> find_override() || mod
+      quote bind_quoted: [mod: mod] do
+        Inject.Registry
+        |> Registry.lookup(mod)
+        |> Enum.reverse()
+        |> find_override() || mod
+      end
     end
+  end
+
+  def i(mod) do
+    inject(mod)
   end
 
   defp find_override([]), do: nil

--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -8,7 +8,7 @@ defmodule Inject do
     :ok
   end
 
-  defmacro inject(mod) do
+  defmacro inject_module(mod) do
     if Application.get_env(:inject, :disabled) do
       mod
     else
@@ -23,6 +23,10 @@ defmodule Inject do
 
   def i(mod) do
     inject(mod)
+  end
+
+  def inject(mod) do
+    inject_module(mod)
   end
 
   defp find_override([]), do: nil

--- a/test/inject_configuration_test.exs
+++ b/test/inject_configuration_test.exs
@@ -19,7 +19,7 @@ defmodule InjectConfigurationTest do
     test "it does not lookup modules in the registry" do
       register(ExampleModule, StubModule)
       Application.put_env(:inject, :disabled, true)
-      assert "unstubbed" = i(ExampleModule).hello()
+      assert {"unstubbed", []} = Code.eval_quoted(quote(do: inject_module(ExampleModule).hello()))
       Application.put_env(:inject, :disabled, false)
     end
   end


### PR DESCRIPTION
this ensures that Application.get_env is called only when inject is enabled in the config. Otherwise, it does not get included in the compiled code.

Tested by putting this branch in an existing project using inject. Confirmed that tests passed there, and that app code in development worked. Also ran `mix test` against this repo.