### PR TITLE
Priortize pid over shared in inject

### DIFF
--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -27,16 +27,15 @@ defmodule Inject do
 
   defp find_override(overrides) do
     overrides
-    |> Enum.reduce_while(nil, fn {pid, {override, [shared: shared]}}, acc ->
-      if pid == self() do
+    |> Enum.reduce_while(nil, fn
+      {pid, {override, _}}, _acc when pid == self() ->
         {:halt, override}
-      else
-        if shared and acc == nil do
-          {:cont, override}
-        else
-          {:cont, acc}
-        end
-      end
+
+      {_, {override, [shared: true]}}, nil ->
+        {:cont, override}
+
+      _, acc ->
+        {:cont, acc}
     end)
     |> case do
       nil -> nil

--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -37,9 +37,5 @@ defmodule Inject do
       _, acc ->
         {:cont, acc}
     end)
-    |> case do
-      nil -> nil
-      override -> override
-    end
   end
 end

--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -26,20 +26,21 @@ defmodule Inject do
   defp find_override([]), do: nil
 
   defp find_override(overrides) do
-    process_override = Enum.find(overrides, fn {pid, _} -> pid == self() end)
-
-    case process_override do
-      {_, {override, _}} ->
-        override
-
-      nil ->
-        shared_override =
-          Enum.find(overrides, fn {_, {_, [shared: shared]}} -> shared == true end)
-
-        case shared_override do
-          {_, {override, _}} -> override
-          nil -> nil
+    overrides
+    |> Enum.reduce_while(nil, fn {pid, {override, [shared: shared]}}, acc ->
+      if pid == self() do
+        {:halt, override}
+      else
+        if shared and acc == nil do
+          {:cont, override}
+        else
+          {:cont, acc}
         end
+      end
+    end)
+    |> case do
+      nil -> nil
+      override -> override
     end
   end
 end

--- a/lib/inject.ex
+++ b/lib/inject.ex
@@ -25,11 +25,21 @@ defmodule Inject do
 
   defp find_override([]), do: nil
 
-  defp find_override([{pid, {override, shared: shared}} | overrides]) do
-    if pid == self() || shared do
-      override
-    else
-      find_override(overrides)
+  defp find_override(overrides) do
+    process_override = Enum.find(overrides, fn {pid, _} -> pid == self() end)
+
+    case process_override do
+      {_, {override, _}} ->
+        override
+
+      nil ->
+        shared_override =
+          Enum.find(overrides, fn {_, {_, [shared: shared]}} -> shared == true end)
+
+        case shared_override do
+          {_, {override, _}} -> override
+          nil -> nil
+        end
     end
   end
 end

--- a/test/inject_test.exs
+++ b/test/inject_test.exs
@@ -150,4 +150,18 @@ defmodule InjectTest do
       assert_receive "stubbed2"
     end
   end
+
+  describe "when a shared override is registered in another process after a local override" do
+    test "the local override is used in the original process" do
+      test_pid = self()
+      register(ExampleModule, StubModule2)
+
+      Task.async(fn ->
+        register(ExampleModule, StubModule, shared: true)
+      end)
+      |> Task.await()
+
+      assert "stubbed2" = i(ExampleModule).hello()
+    end
+  end
 end


### PR DESCRIPTION
Make is so it defaults to the current pid if there is one before checking for shared